### PR TITLE
configure the client via config files

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -170,6 +170,12 @@
   revision = "d0303fe809921458f417bcf828397a65db30a7e4"
 
 [[projects]]
+  name = "github.com/namsral/flag"
+  packages = ["."]
+  revision = "71ceffbeb0ba60fccc853971bb3ed4d7d90bfd04"
+  version = "v1.7.4-pre"
+
+[[projects]]
   name = "github.com/nats-io/go-nats"
   packages = [
     ".",
@@ -245,6 +251,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "b9974ab7cc61935dfbd420fe089a8244354e2a96bbc92dd88b913ef17c79d2c6"
+  inputs-digest = "9c0a1fd421ca39d4292cfdbd9589b39e7e9c6db822c6e48454c6103b60a682c4"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/client/client.go
+++ b/client/client.go
@@ -23,6 +23,13 @@ func (client *Client) Run() {
 	log.Infof("Starting Albion Data Client version %s", version)
 	log.Info("This is a third-party application and is in no way affiliated with Sandbox Interactive or Albion Online.")
 
+	log.Infof("public ingest urls: %s", ConfigGlobal.PublicIngestBaseUrls)
+	log.Infof("private ingest urls: %s", ConfigGlobal.PrivateIngestBaseUrls)
+	log.Infof("disable upload: %v", ConfigGlobal.DisableUpload)
+	log.Infof("offline path: %s", ConfigGlobal.OfflinePath)
+	log.Infof("debug: %v", ConfigGlobal.Debug)
+	log.Infof("listen devices: %s", ConfigGlobal.ListenDevices)
+
 	createDispatcher()
 
 	if ConfigGlobal.Offline {

--- a/cmd/albiondata-client/albiondata-client.go
+++ b/cmd/albiondata-client/albiondata-client.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"flag"
 	"strings"
 	"time"
 
@@ -10,11 +9,19 @@ import (
 	"github.com/broderickhyman/albiondata-client/client"
 	"github.com/broderickhyman/albiondata-client/log"
 	"github.com/broderickhyman/albiondata-client/systray"
+	"github.com/namsral/flag"
 )
 
 var version string
 
 func init() {
+	// set a reference to the configuration file
+	flag.String(
+		flag.DefaultConfigFlagname,
+		"albiondata-client.conf",
+		"Path to a configuration file",
+	)
+
 	flag.StringVar(
 		&client.ConfigGlobal.PublicIngestBaseUrls,
 		"i",


### PR DESCRIPTION
this PR enables an optional configuration of the client via a config file called `albiondata-client.conf`