### PR TITLE
updating Gopkg.toml with the new version of gopacket

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -20,10 +20,11 @@
   revision = "7010621e24804afdf1c9083bd4d1a3e47e1fb63e"
 
 [[projects]]
-  branch = "master"
+  branch = "gopacket-fix"
   name = "github.com/broderickhyman/photon_spectator"
   packages = ["."]
-  revision = "951cd2dce46c16f10ccc952fa2aaeb0c6a9b99ee"
+  revision = "33acfd15f972cd4acb617f1f01883592d36fef3d"
+  source = "https://github.com/gradiuscypher/photon_spectator.git"
 
 [[projects]]
   name = "github.com/ctcpip/notifize"
@@ -99,12 +100,8 @@
 
 [[projects]]
   name = "github.com/google/gopacket"
-  packages = [
-    ".",
-    "layers",
-    "pcap"
-  ]
-  revision = "8af772c0bcc826f671fd7c133917fec9686d720d"
+  packages = [".","layers","pcap"]
+  revision = "1a2aa715ae412f434ae0bbb833442d14880cab8a"
 
 [[projects]]
   name = "github.com/google/uuid"
@@ -120,12 +117,9 @@
 
 [[projects]]
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
-  revision = "20f1fb78b0740ba8c3cb143a61e86ba5c8669768"
-  version = "v0.5.0"
+  packages = [".","simplelru"]
+  revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
+  version = "v0.5.1"
 
 [[projects]]
   branch = "master"
@@ -171,11 +165,7 @@
 
 [[projects]]
   name = "github.com/nats-io/go-nats"
-  packages = [
-    ".",
-    "encoders/builtin",
-    "util"
-  ]
+  packages = [".","encoders/builtin","util"]
   revision = "13c7fc7590db68b18f2015600f8765a02d705b5d"
   version = "v1.7.0"
 
@@ -205,30 +195,20 @@
 
 [[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = [
-    "internal/common",
-    "net"
-  ]
+  packages = ["internal/common","net"]
   revision = "d573c8e3f1c5337585b0e285214e80df7429d8b5"
   source = "https://github.com/gradiuscypher/gopsutil.git"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "ssh/terminal"
-  ]
+  packages = ["ed25519","ed25519/internal/edwards25519","ssh/terminal"]
   revision = "74369b46fc6756741c016591724fd1cb8e26845f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "3b5209105503162ded1863c307ac66fec31120dd"
 
 [[projects]]
@@ -240,10 +220,7 @@
 [[projects]]
   branch = "v0"
   name = "gopkg.in/inconshreveable/go-update.v0"
-  packages = [
-    ".",
-    "download"
-  ]
+  packages = [".","download"]
   revision = "d8b0b1d421aa1cbf392c05869f8abbc669bb7066"
 
 [[projects]]
@@ -255,6 +232,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "91942648dcdc343079021b8046b74191fb0c01a3d5147b282032c1a3bcebabd6"
+  inputs-digest = "954259986296431afcd397b39ca4d57f578f72a4cffc9ef18c8b6bbf724713e1"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -4,7 +4,7 @@
 
 [[constraint]]
   name = "github.com/google/gopacket"
-  revision = "8af772c0bcc826f671fd7c133917fec9686d720d"
+  revision = "1a2aa715ae412f434ae0bbb833442d14880cab8a"
 
 [[constraint]]
   name = "github.com/broderickhyman/photon_spectator"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,7 +1,3 @@
-# ignoring photon_spectator from github so that we can use local version with bugfix
-# ref: https://github.com/golang/dep/issues/935#issuecomment-448291002
-# ignored = ["github.com/broderickhyman/photon_spectator"]
-
 [[constraint]]
   name = "github.com/Sirupsen/logrus"
   version = "1.0.4"
@@ -12,8 +8,7 @@
 
 [[constraint]]
   name = "github.com/broderickhyman/photon_spectator"
-  source = "https://github.com/gradiuscypher/photon_spectator.git"
-  branch = "gopacket-fix"
+  branch = "master"
 
 [[constraint]]
   name = "github.com/mitchellh/go-ps"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -1,3 +1,7 @@
+# ignoring photon_spectator from github so that we can use local version with bugfix
+# ref: https://github.com/golang/dep/issues/935#issuecomment-448291002
+# ignored = ["github.com/broderickhyman/photon_spectator"]
+
 [[constraint]]
   name = "github.com/Sirupsen/logrus"
   version = "1.0.4"
@@ -8,7 +12,8 @@
 
 [[constraint]]
   name = "github.com/broderickhyman/photon_spectator"
-  branch = "master"
+  source = "https://github.com/gradiuscypher/photon_spectator.git"
+  branch = "gopacket-fix"
 
 [[constraint]]
   name = "github.com/mitchellh/go-ps"


### PR DESCRIPTION
**NOTE** : This PR will need to be accepted in lock-step with the related PR to the `photon_spectator` repo, since the client relies on `photon_spectator`, and both `gopacket` versions need to be the same. Once I've created the other PR, I'll link them to each other.

----

This PR will update the `google/gopacket` library to the newest version, which solves the inability to build the project with newer versions of Go. This has been briefly tested to ensure that the compiled client properly sends messages to the NATS network. This has only been tested on Windows, but I'd appreciate help with testing building in OSX and Linux.

For example without updating these libraries in both `photon_spectator` and `albiondata-client` you end up with a `go build` error message similar to this:

```
gradius@gameshell MINGW64 ~/go/src/github.com/broderickhyman/albiondata-client (master)
$ go build cmd/albiondata-client/albiondata-client.go
# github.com/broderickhyman/albiondata-client/vendor/github.com/google/gopacket/pcap
vendor\github.com\google\gopacket\pcap\pcap.go:182:7: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:409:13: identifier "_Ctype_struct_pcap_stat" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:454:49: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:477:10: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:510:41: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:582:66: identifier "_Ctype_struct_bpf_program" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:595:19: identifier "_Ctype_struct_bpf_insn" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:705:34: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo
vendor\github.com\google\gopacket\pcap\pcap.go:708:56: identifier "_Ctype_struct_pcap_addr" may conflict with identifiers generated by cgo
```