### PR TITLE
Websocket Updates, Improved Security, Additional Configurations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ _vendor-[0-9]*
 *.zip
 scripts/albiondata-client
 albiondata-client-output.txt
+config.yaml

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -32,6 +32,12 @@
   version = "v1.0.0"
 
 [[projects]]
+  name = "github.com/fsnotify/fsnotify"
+  packages = ["."]
+  revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
+  version = "v1.4.7"
+
+[[projects]]
   branch = "master"
   name = "github.com/getlantern/context"
   packages = ["."]
@@ -99,11 +105,7 @@
 
 [[projects]]
   name = "github.com/google/gopacket"
-  packages = [
-    ".",
-    "layers",
-    "pcap"
-  ]
+  packages = [".","layers","pcap"]
   revision = "1a2aa715ae412f434ae0bbb833442d14880cab8a"
 
 [[projects]]
@@ -120,12 +122,15 @@
 
 [[projects]]
   name = "github.com/hashicorp/golang-lru"
-  packages = [
-    ".",
-    "simplelru"
-  ]
+  packages = [".","simplelru"]
   revision = "7087cb70de9f7a8bc0a10c375cb0d2280a8edf9c"
   version = "v0.5.1"
+
+[[projects]]
+  name = "github.com/hashicorp/hcl"
+  packages = [".","hcl/ast","hcl/parser","hcl/printer","hcl/scanner","hcl/strconv","hcl/token","json/parser","json/scanner","json/token"]
+  revision = "8cb6e5b959231cc1119e43259c4a608f9c51a241"
+  version = "v1.0.0"
 
 [[projects]]
   branch = "master"
@@ -144,6 +149,12 @@
   packages = ["."]
   revision = "88f551ae580780cc79d12ab4c218ba1ca346b83a"
   version = "v0.1.0"
+
+[[projects]]
+  name = "github.com/magiconair/properties"
+  packages = ["."]
+  revision = "de8848e004dd33dc07a2947b3d76f618a7fc7ef1"
+  version = "v1.8.1"
 
 [[projects]]
   name = "github.com/mattn/go-colorable"
@@ -171,11 +182,7 @@
 
 [[projects]]
   name = "github.com/nats-io/go-nats"
-  packages = [
-    ".",
-    "encoders/builtin",
-    "util"
-  ]
+  packages = [".","encoders/builtin","util"]
   revision = "13c7fc7590db68b18f2015600f8765a02d705b5d"
   version = "v1.7.0"
 
@@ -204,32 +211,64 @@
   revision = "4e1c5567d7c2dd59fa4c7c83d34c2f3528b025d6"
 
 [[projects]]
+  name = "github.com/pelletier/go-toml"
+  packages = ["."]
+  revision = "728039f679cbcd4f6a54e080d2219a4c4928c546"
+  version = "v1.4.0"
+
+[[projects]]
   name = "github.com/shirou/gopsutil"
-  packages = [
-    "internal/common",
-    "net"
-  ]
+  packages = ["internal/common","net"]
   revision = "d573c8e3f1c5337585b0e285214e80df7429d8b5"
   source = "https://github.com/gradiuscypher/gopsutil.git"
 
 [[projects]]
+  name = "github.com/spf13/afero"
+  packages = [".","mem"]
+  revision = "588a75ec4f32903aa5e39a2619ba6a4631e28424"
+  version = "v1.2.2"
+
+[[projects]]
+  name = "github.com/spf13/cast"
+  packages = ["."]
+  revision = "8c9545af88b134710ab1cd196795e7f2388358d7"
+  version = "v1.3.0"
+
+[[projects]]
+  name = "github.com/spf13/jwalterweatherman"
+  packages = ["."]
+  revision = "94f6ae3ed3bceceafa716478c5fbf8d29ca601a1"
+  version = "v1.1.0"
+
+[[projects]]
+  name = "github.com/spf13/pflag"
+  packages = ["."]
+  revision = "298182f68c66c05229eb03ac171abe6e309ee79a"
+  version = "v1.0.3"
+
+[[projects]]
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  revision = "b5bf975e5823809fb22c7644d008757f78a4259e"
+  version = "v1.4.0"
+
+[[projects]]
   branch = "master"
   name = "golang.org/x/crypto"
-  packages = [
-    "ed25519",
-    "ed25519/internal/edwards25519",
-    "ssh/terminal"
-  ]
+  packages = ["ed25519","ed25519/internal/edwards25519","ssh/terminal"]
   revision = "74369b46fc6756741c016591724fd1cb8e26845f"
 
 [[projects]]
   branch = "master"
   name = "golang.org/x/sys"
-  packages = [
-    "unix",
-    "windows"
-  ]
+  packages = ["unix","windows"]
   revision = "3b5209105503162ded1863c307ac66fec31120dd"
+
+[[projects]]
+  name = "golang.org/x/text"
+  packages = ["internal/gen","internal/triegen","internal/ucd","transform","unicode/cldr","unicode/norm"]
+  revision = "342b2e1fbaa52c93f31447ad2c6abc048c63e475"
+  version = "v0.3.2"
 
 [[projects]]
   branch = "master"
@@ -240,10 +279,7 @@
 [[projects]]
   branch = "v0"
   name = "gopkg.in/inconshreveable/go-update.v0"
-  packages = [
-    ".",
-    "download"
-  ]
+  packages = [".","download"]
   revision = "d8b0b1d421aa1cbf392c05869f8abbc669bb7066"
 
 [[projects]]
@@ -252,9 +288,15 @@
   packages = ["."]
   revision = "0a84660828b24d25b35525c9a1f1f51267f8da91"
 
+[[projects]]
+  name = "gopkg.in/yaml.v2"
+  packages = ["."]
+  revision = "51d6538a90f86fe93ac480b35f37b2be17fef232"
+  version = "v2.2.2"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "1ddb721303faa33d4f8fe2be78d7780b2d9c80280e65efb53e04671f4c0068e6"
+  inputs-digest = "88b70f20c6a22ad5ea482091f45c033cb2400427718038783a548b4bce732396"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -37,3 +37,7 @@
 
 [[constraint]]
   name = "github.com/mattn/go-colorable"
+
+[[constraint]]
+  name = "github.com/spf13/viper"
+  version = "1.4.0"

--- a/client/config.go
+++ b/client/config.go
@@ -11,6 +11,8 @@ type config struct {
 	LogLevel              string
 	VersionDump           bool
 	ListenDevices         string
+	EnableWebsockets      bool
+	AllowedWSHosts        []string
 }
 
 var ConfigGlobal = &config{

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -8,7 +8,6 @@ import (
 
 	"github.com/broderickhyman/albiondata-client/lib"
 	"github.com/broderickhyman/albiondata-client/log"
-	"github.com/broderickhyman/albiondata-client/notification"
 )
 
 type dispatcher struct {
@@ -69,13 +68,18 @@ func sendMsgToPublicUploaders(upload interface{}, topic string, state *albionSta
 }
 
 func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, state *albionState) {
-	if state.CharacterName == "" || state.CharacterId == "" {
-		log.Error("The player name or id has not been set. Please restart the game and make sure the client is running.")
-		notification.Push("The player name or id has not been set. Please restart the game and make sure the client is running.")
-		return
-	}
+	// TODO (gradius): determine how to capture character name/id, if possible
+	// TODO (gradius): current removed this for now, so no character ID/name will show.
+	// state.CharacterName = "ExampleName"
+	// state.CharacterId = "123456"
 
-	upload.Personalize(state.CharacterId, state.CharacterName)
+	// if state.CharacterName == "" || state.CharacterId == "" {
+	// 	log.Error("The player name or id has not been set. Please restart the game and make sure the client is running.")
+	// 	notification.Push("The player name or id has not been set. Please restart the game and make sure the client is running.")
+	// 	return
+	// }
+
+	// upload.Personalize(state.CharacterId, state.CharacterName)
 
 	data, err := json.Marshal(upload)
 	if err != nil {
@@ -98,6 +102,7 @@ func sendMsgToUploaders(msg []byte, topic string, uploaders []uploader) {
 }
 
 func runHTTPServer() {
+	// TODO (gradius): add authentication/authorization
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		serveWs(wsHub, w, r)
 	})
@@ -110,7 +115,9 @@ func runHTTPServer() {
 }
 
 func sendMsgToWebSockets(msg []byte, topic string) {
-	var test string
-	test = "{\"topic\": \"" + topic + "\", \"data\": " + string(msg) + "}"
-	wsHub.broadcast <- []byte(test)
+	// TODO (gradius): send JSON data with topic string
+	// TODO (gradius): this seems super hacky, and I'm sure there's a better way.
+	var result string
+	result = "{\"topic\": \"" + topic + "\", \"data\": " + string(msg) + "}"
+	wsHub.broadcast <- []byte(result)
 }

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -74,18 +74,15 @@ func sendMsgToPublicUploaders(upload interface{}, topic string, state *albionSta
 }
 
 func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, state *albionState) {
-	// TODO (gradius): determine how to capture character name/id, if possible
-	// TODO (gradius): current removed this for now, so no character ID/name will show.
-	// state.CharacterName = "ExampleName"
-	// state.CharacterId = "123456"
-
+	// TODO: Re-enable this when issue #14 is fixed
+	// Will personalize with blanks for now in order to allow people to see the format
 	// if state.CharacterName == "" || state.CharacterId == "" {
 	// 	log.Error("The player name or id has not been set. Please restart the game and make sure the client is running.")
 	// 	notification.Push("The player name or id has not been set. Please restart the game and make sure the client is running.")
 	// 	return
 	// }
 
-	// upload.Personalize(state.CharacterId, state.CharacterName)
+	upload.Personalize(state.CharacterId, state.CharacterName)
 
 	data, err := json.Marshal(upload)
 	if err != nil {

--- a/client/dispatcher.go
+++ b/client/dispatcher.go
@@ -26,9 +26,11 @@ func createDispatcher() {
 		privateUploaders: createUploaders(strings.Split(ConfigGlobal.PrivateIngestBaseUrls, ",")),
 	}
 
-	wsHub = newHub()
-	go wsHub.run()
-	go runHTTPServer()
+	if ConfigGlobal.EnableWebsockets {
+		wsHub = newHub()
+		go wsHub.run()
+		go runHTTPServer()
+	}
 }
 
 func createUploaders(targets []string) []uploader {
@@ -64,7 +66,11 @@ func sendMsgToPublicUploaders(upload interface{}, topic string, state *albionSta
 
 	sendMsgToUploaders(data, topic, dis.publicUploaders)
 	sendMsgToUploaders(data, topic, dis.privateUploaders)
-	sendMsgToWebSockets(data, topic)
+
+	// If websockets are enabled, send the data there too
+	if ConfigGlobal.EnableWebsockets {
+		sendMsgToWebSockets(data, topic)
+	}
 }
 
 func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, state *albionState) {
@@ -88,7 +94,11 @@ func sendMsgToPrivateUploaders(upload lib.PersonalizedUpload, topic string, stat
 	}
 
 	sendMsgToUploaders(data, topic, dis.privateUploaders)
-	sendMsgToWebSockets(data, topic)
+
+	// If websockets are enabled, send the data there too
+	if ConfigGlobal.EnableWebsockets {
+		sendMsgToWebSockets(data, topic)
+	}
 }
 
 func sendMsgToUploaders(msg []byte, topic string, uploaders []uploader) {
@@ -102,7 +112,6 @@ func sendMsgToUploaders(msg []byte, topic string, uploaders []uploader) {
 }
 
 func runHTTPServer() {
-	// TODO (gradius): add authentication/authorization
 	http.HandleFunc("/ws", func(w http.ResponseWriter, r *http.Request) {
 		serveWs(wsHub, w, r)
 	})

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -5,9 +5,9 @@
 package client
 
 import (
-	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -36,10 +36,20 @@ var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
-		fmt.Println(ConfigGlobal.AllowedWSHosts)
-		fmt.Println(ConfigGlobal.EnableWebsockets)
-		fmt.Println(r.Header["Origin"])
-		return true
+		var originHost string
+		var originHostname string
+		originHost = r.Header.Get("Origin")
+
+		if originHost != "null" {
+			originHostname = (strings.Split((strings.Split(originHost, "//")[1]), ":")[0])
+			for _, v := range ConfigGlobal.AllowedWSHosts {
+				if v == originHostname {
+					return true
+				}
+			}
+		}
+
+		return false
 	},
 }
 

--- a/client/ws_client.go
+++ b/client/ws_client.go
@@ -5,6 +5,7 @@
 package client
 
 import (
+	"fmt"
 	"log"
 	"net/http"
 	"time"
@@ -35,6 +36,9 @@ var upgrader = websocket.Upgrader{
 	ReadBufferSize:  1024,
 	WriteBufferSize: 1024,
 	CheckOrigin: func(r *http.Request) bool {
+		fmt.Println(ConfigGlobal.AllowedWSHosts)
+		fmt.Println(ConfigGlobal.EnableWebsockets)
+		fmt.Println(r.Header["Origin"])
 		return true
 	},
 }

--- a/cmd/albiondata-client/albiondata-client.go
+++ b/cmd/albiondata-client/albiondata-client.go
@@ -4,17 +4,28 @@ import (
 	"flag"
 	"strings"
 	"time"
+	"fmt"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/broderickhyman/albiondata-client/client"
 	"github.com/broderickhyman/albiondata-client/log"
 	"github.com/broderickhyman/albiondata-client/systray"
 	"github.com/broderickhyman/go-githubupdate/updater"
+	"github.com/spf13/viper"
 )
 
 var version string
 
 func init() {
+	// Setup the config file and parse values
+	viper.SetConfigName("config")
+	viper.AddConfigPath(".")
+	err := viper.ReadInConfig()
+	if err != nil { panic(fmt.Errorf("%s", err))}
+
+	client.ConfigGlobal.EnableWebsockets = viper.GetBool("EnableWebsockets")
+	client.ConfigGlobal.AllowedWSHosts = viper.GetStringSlice("AllowedWebsocketHosts")
+
 	flag.StringVar(
 		&client.ConfigGlobal.PublicIngestBaseUrls,
 		"i",

--- a/cmd/albiondata-client/albiondata-client.go
+++ b/cmd/albiondata-client/albiondata-client.go
@@ -4,7 +4,6 @@ import (
 	"flag"
 	"strings"
 	"time"
-	"fmt"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/broderickhyman/albiondata-client/client"
@@ -21,7 +20,11 @@ func init() {
 	viper.SetConfigName("config")
 	viper.AddConfigPath(".")
 	err := viper.ReadInConfig()
-	if err != nil { panic(fmt.Errorf("%s", err))}
+
+	// if we cannot find the configuration file, set Websockets to false
+	if err != nil {
+		viper.Set("EnableWebsockets", false)
+	}
 
 	client.ConfigGlobal.EnableWebsockets = viper.GetBool("EnableWebsockets")
 	client.ConfigGlobal.AllowedWSHosts = viper.GetStringSlice("AllowedWebsocketHosts")

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,0 @@
-EnableWebsockets: True
-AllowedWebsocketHosts:
-  - aom.grds.io
-  - bob.grds.io

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,4 @@
+EnableWebsockets: True
+AllowedWebsocketHosts:
+  - aom.grds.io
+  - bob.grds.io

--- a/config.yaml.example
+++ b/config.yaml.example
@@ -1,0 +1,3 @@
+EnableWebsockets: False
+AllowedWebsocketHosts:
+  - www.example.com


### PR DESCRIPTION
## Change Summary
This set of changes accomplishes a few different things related to the previously implemented Websocket listener. I wanted to improve the usability of the system while also making it more secure and allowing the user to opt-in to hosting a Websocket listener rather than starting one automatically. Changes are broken down below.

## Configuration Parsing - Viper
Additional configuration options: I've included [Viper](https://github.com/spf13/viper) as a configuration parser. This allowed me to include `config.yaml` as configuration file. This configuration file is where the user can configure which sites/hostnames are allowed to access their Websocket Listener, as well as whether to enable the Websocket Listener at all.

## Configuration - Websocket Related
I've added two new configuration sections to `client/config.go` related to the Websocket configuration. 

* `EnableWebsockets` is a `bool` that determines if we start the Websocket listener or if we attempt to send data to a Websocket host. If this `bool` is `false`, then no listener is started, and no data is sent to the listener from the client.
* `AllowedWSHosts` is an array of Strings that will be used to validate the Origin of requests from the web browser/localhost to ensure that the user has allowed that Origin to access the Websocket listener.

By default, if `config.yaml` doesn't exist, `EnableWebsockets` is set to `false`.

## `dispatcher.go` - Websocket Listener Check
This change goes along with the configuration changes for the Websocket listeners. If those configurations are set to `false`, or if the configuration doesn't exist, the code related to hosting + starting the Websocket listener is never used. It also never attempts to upload to the Websocket host if disabled, in each of the uploader blocks.

For the time being, I've also removed the code (and the errors) related to uploading to private Upload hosts. Since we weren't setting the `CharacterName` or `CharacterId`, I've commented out this state. 

**Feedback**: Also, starting on [line 126](https://github.com/broderickhyman/albiondata-client/compare/master...gradiuscypher:webhook-implement?expand=1#diff-0f17fe0ac1adbbe0e01d2591696fcb8fR126), I've updated the `sendMsgToWebSockets` function to include the data from the event, but it feels very hacked together, and I think there might be a better way.

**Note:** The only risk I can see coming from this change is if someone was using the client to upload to a private NATS host. Suddenly, the events that were being stopped from being uploaded will now actually be uploaded to the private NATS host.  If we feel this risk is too much, we can re-enable the checks back to the state it was before these changes.

## `ws_client.go` - Host checking
The changes starting on [line 39](https://github.com/broderickhyman/albiondata-client/compare/master...gradiuscypher:webhook-implement?expand=1#diff-079950525ae00821870af02bce7bbf7fR39) focus on checking the origin of the request to connect to the Websocket listener. Originally, any host that knew of the port could attempt to connect to the Websocket listener and see any information being published there. Now, with the origin checking, only hosts that are configured in `config.yaml` under the `AllowedWebsocketHosts` section will be allowed to connect. All others will be denied.

**Note:** The only risk I can see coming from this change is if someone was using the Websocket listener as a way to get data from the Albion Data Client into their own tools. I'm not aware of any users doing this, but if this risk is too large, then we can provide instructions on how to connect and enable the new Websocket listener. I would prefer that we don't go back to listening on public interfaces without any validation, as this left an opening for any site that knew it existed to also connect to the Websocket listener.