### PR TITLE
Adding Market History

### DIFF
--- a/client/albion_state.go
+++ b/client/albion_state.go
@@ -6,11 +6,26 @@ import (
 	"github.com/broderickhyman/albiondata-client/notification"
 )
 
+const CACHE_SIZE = 256
+
+type marketHistoryInfo struct {
+	albionId  uint32
+	timescale lib.Timescale
+	quality   uint8
+}
+
 type albionState struct {
 	LocationId     int
 	LocationString string
 	CharacterId    lib.CharacterID
 	CharacterName  string
+
+	// A lot of information is sent out but not contained in the response when requesting marketHistory (e.g. ID)
+	// This information is stored in marketHistoryInfo
+	// This array acts as a type of cache for that info
+	// The index is the message number (param255) % CACHE_SIZE
+	marketHistoryIDLookup [CACHE_SIZE]marketHistoryInfo
+	// TODO could this be improved?!
 }
 
 func (state albionState) IsValidLocation() bool {

--- a/client/decode.go
+++ b/client/decode.go
@@ -21,6 +21,8 @@ func decodeRequest(params map[string]interface{}) (operation operation, err erro
 		operation = &operationGetGameServerByCluster{}
 	case opAuctionGetOffers:
 		operation = &operationAuctionGetOffers{}
+	case opAuctionGetItemAverageStats:
+		operation = &operationAuctionGetItemAverageStats{}
 	case opGetClusterMapInfo:
 		operation = &operationGetClusterMapInfo{}
 	case opGoldMarketGetAverageInfo:
@@ -52,6 +54,8 @@ func decodeResponse(params map[string]interface{}) (operation operation, err err
 		operation = &operationAuctionGetOffersResponse{}
 	case opAuctionGetRequests:
 		operation = &operationAuctionGetRequestsResponse{}
+	case opAuctionGetItemAverageStats:
+		operation = &operationAuctionGetItemAverageStatsResponse{}
 	case opReadMail:
 		operation = &operationReadMail{}
 	case opGetClusterMapInfo:

--- a/client/operation_auction_get_item_average_stats.go
+++ b/client/operation_auction_get_item_average_stats.go
@@ -1,0 +1,71 @@
+package client
+
+import (
+	"github.com/broderickhyman/albiondata-client/lib"
+	"github.com/broderickhyman/albiondata-client/log"
+)
+
+type operationAuctionGetItemAverageStats struct {
+	ItemID      uint32        `mapstructure:"1"`
+	Quality     uint8         `mapstructure:"2"`
+	Enchantment uint32        `mapstructure:"4"`
+	Timescale   lib.Timescale `mapstructure:"3"`
+	MessageID   uint64        `mapstructure:"255"`
+}
+
+func (op operationAuctionGetItemAverageStats) Process(state *albionState) {
+	var index = op.MessageID % CACHE_SIZE
+	mhInfo := marketHistoryInfo{
+		albionId:  op.ItemID,
+		timescale: op.Timescale,
+		quality:   op.Quality,
+	}
+	state.marketHistoryIDLookup[index] = mhInfo
+	log.Debugf("Market History - Caching %d at %d.", mhInfo.albionId, index)
+}
+
+type operationAuctionGetItemAverageStatsResponse struct {
+	ItemAmounts   []uint64 `mapstructure:"0"`
+	SilverAmounts []uint64 `mapstructure:"1"`
+	Timestamps    []uint64 `mapstructure:"2"`
+	MessageID     int      `mapstructure:"255"`
+}
+
+func (op operationAuctionGetItemAverageStatsResponse) Process(state *albionState) {
+	var index = op.MessageID % CACHE_SIZE
+	var mhInfo = state.marketHistoryIDLookup[index]
+	log.Debugf("Market History - Loaded itemID %d from cache at index %d", mhInfo.albionId, index)
+	log.Debug("Got response to GetItemAverageStats operation for the itemID[", mhInfo.albionId, "] of quality: ", mhInfo.quality, " and on the timescale: ", mhInfo.timescale)
+
+	if !state.IsValidLocation() {
+		return
+	}
+
+	var histories []*lib.MarketHistory
+
+	// TODO can we make this safer? Right now we just assume all the arrays are the same length as the number of item amounts
+	for i := range op.ItemAmounts {
+
+		history := &lib.MarketHistory{}
+		history.AlbionID = mhInfo.albionId
+		history.LocationID = state.LocationId
+		history.QualityLevel = mhInfo.quality
+		history.Timescale = mhInfo.timescale
+		history.ItemAmount = op.ItemAmounts[i]
+		history.SilverAmount = op.SilverAmounts[i]
+		history.Timestamp = op.Timestamps[i]
+		histories = append(histories, history)
+	}
+
+	if len(histories) < 1 {
+		log.Info("Auction Stats Reponse - no history\n\n")
+		return
+	}
+
+	upload := lib.MarketHistoriesUpload{
+		Histories: histories,
+	}
+
+	log.Infof("Sending %d item average stats to ingest for albionID %d", len(histories), histories[0].AlbionID)
+	sendMsgToPublicUploaders(upload, lib.NatsMarketHistoriesIngest, state)
+}

--- a/lib/marketHistory.go
+++ b/lib/marketHistory.go
@@ -1,0 +1,62 @@
+package lib
+
+import (
+	"fmt"
+)
+
+// Timescale represents the three different timescale views available for market history
+type Timescale uint8
+
+const ( // iota defaults to 0 and then incremeneted by 1
+	// Hours - 0 means we are looking at the 24 hour scale
+	Hours Timescale = iota
+	// Days - 1 means we are looking at the 7 day scale
+	Days Timescale = iota // c1 == 1
+	// Weeks - 2 means we are looking at the 4 week scale
+	Weeks Timescale = iota // c2 == 2
+) // consts for marketHistory
+
+func (scale Timescale) String() string {
+	names := [...]string{
+		"Hours",
+		"Days",
+		"Weeks"}
+
+	if scale < Hours || scale > Weeks {
+		return "Invalid Timescale"
+	}
+
+	return names[scale]
+}
+
+// MarketHistory contains the ItemID, Timescale, and 3 data arrays (Item amount, silver amount, and timetamp)
+// These values come over the wire with indexes aligned, but are likely not sorted by time.
+// Their sizes also value based on need as mentioned below.
+type MarketHistory struct {
+	AlbionID     uint32    `json:"AlbionID"`
+	LocationID   int       `json:"LocationId"`
+	QualityLevel uint8     `json:"QualityLevel"`
+	Timescale    Timescale `json:"Timescale"`
+	ItemAmount   uint64    `json:"ItemAmount"`
+	SilverAmount uint64    `json:"SilverAmount"`
+	Timestamp    uint64    `json:"Timestamp"`
+	// even for the same parameter type, array type will differ depending on the size of the data values being sent.
+	// For this reason, we'll be safe and use the largest expected values.
+}
+
+// StringArray for MarketHistory, duh
+func (m *MarketHistory) StringArray() []string {
+	return []string{
+		fmt.Sprintf("%d", m.AlbionID),
+		fmt.Sprintf("%d", m.LocationID),
+		fmt.Sprintf("%d", m.QualityLevel),
+		fmt.Sprintf("%s", m.Timescale),
+		fmt.Sprintf("%d", m.ItemAmount),
+		fmt.Sprintf("%d", m.SilverAmount),
+		fmt.Sprintf("%d", m.Timestamp),
+	}
+}
+
+type MarketHistoriesUpload struct {
+	Histories []*MarketHistory `json:"MarketHistories"`
+}

--- a/lib/nats.go
+++ b/lib/nats.go
@@ -2,13 +2,15 @@ package lib
 
 const (
 	// Public Topics
-	NatsGoldPricesIngest    = "goldprices.ingest"
-	NatsGoldPricesDeduped   = "goldprices.deduped"
-	NatsMarketOrdersIngest  = "marketorders.ingest"
-	NatsMarketOrdersDeduped = "marketorders.deduped"
-	NatsValidMarketOrders   = "validmarketorders"
-	NatsMapDataIngest       = "mapdata.ingest"
-	NatsMapDataDeduped      = "mapdata.deduped"
+	NatsGoldPricesIngest       = "goldprices.ingest"
+	NatsGoldPricesDeduped      = "goldprices.deduped"
+	NatsMarketOrdersIngest     = "marketorders.ingest"
+	NatsMarketOrdersDeduped    = "marketorders.deduped"
+	NatsMarketHistoriesIngest  = "markethistories.ingest"
+	NatsMarketHistoriesDeduped = "markethistories.deduped"
+	NatsValidMarketOrders      = "validmarketorders"
+	NatsMapDataIngest          = "mapdata.ingest"
+	NatsMapDataDeduped         = "mapdata.deduped"
 
 	// Private Topics
 	NatsSkillData           = "skills"


### PR DESCRIPTION
Added the base code needed to parse auction get item average stats operations. This is very much still a work in progress, but is a good initial start. The ID matching in particular is very sketchy and I'd like some extra eyes to make sure my assumptions are safe and we aren't mismatching anything. Any and all feedback welcome.

NOTE - This requires a forthcoming patch to the photon spectator library (specifically decode_reliable_message.go). Without this patch, some item amounts will erroneously be 0.