### PR TITLE
Fix uint overflow in market history

### DIFF
--- a/client/operation_auction_get_item_average_stats.go
+++ b/client/operation_auction_get_item_average_stats.go
@@ -27,7 +27,7 @@ func (op operationAuctionGetItemAverageStats) Process(state *albionState) {
 }
 
 type operationAuctionGetItemAverageStatsResponse struct {
-	ItemAmounts   []uint64 `mapstructure:"0"`
+	ItemAmounts   []int64 `mapstructure:"0"`
 	SilverAmounts []uint64 `mapstructure:"1"`
 	Timestamps    []uint64 `mapstructure:"2"`
 	MessageID     int      `mapstructure:"255"`

--- a/client/operation_auction_get_item_average_stats.go
+++ b/client/operation_auction_get_item_average_stats.go
@@ -47,7 +47,12 @@ func (op operationAuctionGetItemAverageStatsResponse) Process(state *albionState
 
 	// TODO can we make this safer? Right now we just assume all the arrays are the same length as the number of item amounts
 	for i := range op.ItemAmounts {
-
+		// sometimes opAuctionGetItemAverageStats receives negative item amounts
+		// they make no sense and so are dropped
+		if op.ItemAmounts[i] < 0 {
+			log.Infof("Market History - Ignoring negative item amount %d for %d silver on %d", op.ItemAmounts[i], op.SilverAmounts[i], op.Timestamps[i])
+			continue
+		}
 		history := &lib.MarketHistory{}
 		history.ItemAmount = op.ItemAmounts[i]
 		history.SilverAmount = op.SilverAmounts[i]

--- a/lib/marketHistory.go
+++ b/lib/marketHistory.go
@@ -31,7 +31,7 @@ func (scale Timescale) String() string {
 // These values come over the wire with indexes aligned, but are likely not sorted by time.
 // Their sizes also value based on need as mentioned below.
 type MarketHistory struct {
-	ItemAmount   uint64 `json:"ItemAmount"`
+	ItemAmount   int64 `json:"ItemAmount"`
 	SilverAmount uint64 `json:"SilverAmount"`
 	Timestamp    uint64 `json:"Timestamp"`
 	// even for the same parameter type, array type will differ depending on the size of the data values being sent.


### PR DESCRIPTION
This PR attempts to fix the issue with uint overflows due to negative item amounts preventing market history from being updated.