### PR TITLE
Improve negative count import

### DIFF
--- a/client/operation_auction_get_item_average_stats.go
+++ b/client/operation_auction_get_item_average_stats.go
@@ -48,10 +48,16 @@ func (op operationAuctionGetItemAverageStatsResponse) Process(state *albionState
 	// TODO can we make this safer? Right now we just assume all the arrays are the same length as the number of item amounts
 	for i := range op.ItemAmounts {
 		// sometimes opAuctionGetItemAverageStats receives negative item amounts
-		// they make no sense and so are dropped
 		if op.ItemAmounts[i] < 0 {
-			log.Debugf("Market History - Ignoring negative item amount %d for %d silver on %d", op.ItemAmounts[i], op.SilverAmounts[i], op.Timestamps[i])
-			continue
+			if op.ItemAmounts[i] < -124 {
+				// still don't know what to do with these
+				log.Debugf("Market History - Ignoring negative item amount %d for %d silver on %d", op.ItemAmounts[i], op.SilverAmounts[i], op.Timestamps[i])
+				continue
+			}
+			// however these can be interpreted by adding them to 256
+			// TODO: make more sense of this, (perhaps there is a better way)
+			log.Debugf("Market History - Interpreting negative item amount %d as %d for %d silver on %d", op.ItemAmounts[i], 256+op.ItemAmounts[i], op.SilverAmounts[i], op.Timestamps[i])
+			op.ItemAmounts[i] = 256 + op.ItemAmounts[i]
 		}
 		history := &lib.MarketHistory{}
 		history.ItemAmount = op.ItemAmounts[i]


### PR DESCRIPTION
Previously history entries having negative item counts were dropped as it was better than failing the upload altogether.
This PR attempts to fix some of the negative counts by calculating the correct positive values.

https://www.albion-online-data.com/api/v2/stats/history/T6_2H_POLEHAMMER?locations=Black Market&qualities=2&time-scale=6 was used for testing the upload as for some reason almost all of the counts are negative and thus very few entries were uploaded. Now it looks much more complete.