### PR TITLE
add -no-limit parameter

### DIFF
--- a/albiondata-client.go
+++ b/albiondata-client.go
@@ -128,6 +128,13 @@ func init() {
 		false,
 		"Ignore the decoding errors when debugging",
 	)
+
+	flag.BoolVar(
+		&client.ConfigGlobal.NoCPULimit,
+		"no-limit",
+		false,
+		"Use all available CPU cores",
+	)
 }
 
 func main() {

--- a/client/config.go
+++ b/client/config.go
@@ -21,6 +21,7 @@ type config struct {
 	RecordPath                     string
 	PrivateIngestBaseUrls          string
 	PublicIngestBaseUrls           string
+	NoCPULimit                     bool
 }
 
 //ConfigGlobal global config data

--- a/client/uploader_http_pow.go
+++ b/client/uploader_http_pow.go
@@ -28,12 +28,14 @@ type Pow struct {
 // newHTTPUploaderPow creates a new HTTP uploader
 func newHTTPUploaderPow(url string) uploader {
 
-	// Limit to 25% of available cpu cores
-	procs := runtime.NumCPU() / 4
-	if procs < 1 {
-		procs = 1
+	if !ConfigGlobal.NoCPULimit {
+		// Limit to 25% of available cpu cores
+		procs := runtime.NumCPU() / 4
+		if procs < 1 {
+			procs = 1
+		}
+		runtime.GOMAXPROCS(procs)
 	}
-	runtime.GOMAXPROCS(procs)
 
 	return &httpUploaderPow{
 		baseURL:   strings.Replace(url, "http+pow", "http", -1),


### PR DESCRIPTION
Skips the limitation of the go runtime to 25% of the cpu cores